### PR TITLE
made all images on z-axis page clickable (untested)

### DIFF
--- a/content/zaxis.md
+++ b/content/zaxis.md
@@ -1,10 +1,10 @@
 # Z-Axis Assembly
 
-[![exploded view of Gantry Carriage](tPictures/PS20031_2.png)](tPictures/PS20031_16.png)
-![](tPictures/so_gantry_carriage_2.jpg)
-![](tPictures/so_z_axis_parts_2.jpg)
-![](tPictures/so_assembly_gantry_carriage_2.jpg)
-![](tPictures/so_gantry_sc_x_y_axes2.jpg)
+[![exploded view of Gantry Carriage](tPictures/PS20031_2.png)](content/tPictures/PS20031_16.png)
+[![](tPictures/so_gantry_carriage_2.jpg)](content/tPictures/so_gantry_carriage_32.jpg)
+[![](tPictures/so_z_axis_parts_2.jpg)](content/tPictures/so_z_axis_parts_32.jpg)
+[![](tPictures/so_assembly_gantry_carriage_2.jpg)](content/tPictures/so_assembly_gantry_carriage_32.jpg)
+[![](tPictures/so_gantry_sc_x_y_axes2.jpg)](content/tPictures/so_gantry_sc_x_y_axes_16.jpg)
 
 The Z-axis assembly is comprised of several sub-assemblies. When assembling it, it is best to select a Motor Mount Carriage (PS20022) which already has a stepper motor in place.
 
@@ -12,9 +12,9 @@ The Z-axis assembly is comprised of several sub-assemblies. When assembling it, 
 
 ##Z Assembly Carriage (PS20021)
 
-![exploded view of Z Assembly Carriage](tPictures/PS20021_2.png)
-![Assembled Z Assembly Carriage](tPictures/so_z_assembly_carriage_2.jpg)
-![Assembled Z Assembly Carriage Parts and Tools](tPictures/so_z_assembly_carriage_parts_2.jpg)
+[![exploded view of Z Assembly Carriage](tPictures/PS20021_2.png)](content/tPictures/PS20021_16.png)
+[![Assembled Z Assembly Carriage](tPictures/so_z_assembly_carriage_2.jpg)](content/tPictures/so_z_assembly_carriage_32.jpg)
+[![Assembled Z Assembly Carriage Parts and Tools](tPictures/so_z_assembly_carriage_parts_2.jpg)](content/tPictures/so_z_assembly_carriage_parts_32.jpg)
 
 ###Requirements
 
@@ -38,11 +38,11 @@ This is the plate the Z-axis will attach to (it is identical to the Motor Mount 
 
 ##Spindle Carriage Assembly (PS20029)
 
-![exploded view of Spindle Carriage Assembly](tPictures/PS20029_2.png)
-![](tPictures/so_spindle_carriage_2.jpg)
-![](tPictures/so_spindle_carriage_parts_2.jpg)
-![](tPictures/so_vwi_vwheel_spacer_tools_2.jpg)
-![](tPictures/so_vwi_smoothidler_tools_2.jpg)
+[![exploded view of Spindle Carriage Assembly](tPictures/PS20029_2.png)](content/tPictures/PS20029_16.png)
+[![](tPictures/so_spindle_carriage_2.jpg)](content/tPictures/so_spindle_carriage_32.jpg)
+[![](tPictures/so_spindle_carriage_parts_2.jpg)](content/tPictures/so_spindle_carriage_parts_32.jpg)
+[![](tPictures/so_vwi_vwheel_spacer_tools_2.jpg)](content/tPictures/so_vwi_vwheel_spacer_tools_16.jpg)
+[![](tPictures/so_vwi_smoothidler_tools_2.jpg)](content/tPictures/so_vwi_smoothidler_tools_16.jpg)
 
 ###Requirements
 
@@ -69,9 +69,9 @@ Place the V-wheels (**\#7**) and the Delrin Lead nut (**\#2**, for the Z-axis Ra
 
 ##Z-Axis Rail Assembly (PS20028)
 
-![exploded view of Z-Axis Rail Assembly](tPictures/PS20028_2.png)
-![Z-Axis Rail Assembly Parts](tPictures/so_z_axis_rail_parts_2.jpg)
-![Z-Axis Rail Assembly](tPictures/so_z_axis_rail_2.jpg)
+[![exploded view of Z-Axis Rail Assembly](tPictures/PS20028_2.png)](content/tPictures/PS20028_16.png)
+[![Z-Axis Rail Assembly Parts](tPictures/so_z_axis_rail_parts_2.jpg)](content/tPictures/so_z_axis_rail_parts_32.jpg)
+[![Z-Axis Rail Assembly](tPictures/so_z_axis_rail_2.jpg)](content/tPictures/so_z_axis_rail_32.jpg)
 
 **Note:** The above exploded view does not show the wavy washer (PS20017) which goes on top of the flanged bearing.
 
@@ -127,7 +127,7 @@ Assemble this from the inside out, starting with the smallest pieces.
 
 ####Threaded Rod
 
-[![threaded rod, flexible coupler and nuts shown with ruler](tPictures/so_z_axis_dimensions_4.jpg)](content/tPictures/so_z_axis_dimensions_8.jpg)
+[![threaded rod, flexible coupler and nuts shown with ruler](tPictures/so_z_axis_dimensions_4.jpg)](content/tPictures/so_z_axis_dimensions_32.jpg)
 
 **Note:** Check your rod's straightness (one way is by rolling it on a flat surface) before assembly and check to see that the threaded rod runs smoothly on the Delrin Lead nut --- if it doesn't, run the nut along the rod until it does. Using a drill is one option. Be certain the nut is free of debris or other materials. 
 
@@ -143,10 +143,10 @@ Tighten everything.
 
 ###Z-Axis
 
-![exploded view of Z-axis](tPictures/PS20030_2.png)
-![bolts, washers and insertion nuts](tPictures/so_z_axis_bolts_washers_nuts_2.jpg)
-![sub-assemblies shown with hardware](tPictures/so_assembly_pre_gantry_carriage_2.jpg)
-![two Z-axis sub-assemblies](tPictures/so_assembly_gantry_carriage_2.jpg)
+[![exploded view of Z-axis](tPictures/PS20030_2.png)](content/tPictures/PS20030_16.png)
+[![bolts, washers and insertion nuts](tPictures/so_z_axis_bolts_washers_nuts_2.jpg)](content/tPictures/so_z_axis_bolts_washers_nuts_16.jpg)
+[![sub-assemblies shown with hardware](tPictures/so_assembly_pre_gantry_carriage_2.jpg)](content/tPictures/so_assembly_pre_gantry_carriage_32.jpg)
+[![two Z-axis sub-assemblies](tPictures/so_assembly_gantry_carriage_2.jpg)](content/tPictures/so_assembly_gantry_carriage_32.jpg)
 
 1. PS20021 **Z-Assembly Carriage** x 1 pcs.
 - PS20028 **Z-Axis Rail Assembly** x 1 pcs.
@@ -163,9 +163,9 @@ Turn the eccentric nuts on the Spindle Carriage Assembly (**\#3**) so that they 
 
 ##Sub Gantry (PS20023)
 
-![](tPictures/PS20031_2.png)
-![](tPictures/so_gantry_carriage_2.jpg)
-![](tPictures/so_gantry_sc_carriage_2.jpg)
+[![](tPictures/PS20031_2.png)](content/tPictures/PS20031_16.png)
+[![](tPictures/so_gantry_carriage_2.jpg)](content/tPictures/so_gantry_carriage_32.jpg)
+[![](tPictures/so_gantry_sc_carriage_2.jpg)](content/tPictures/so_gantry_sc_carriage_16.jpg)
 
 ###Requirements
 

--- a/content/zaxis.md
+++ b/content/zaxis.md
@@ -1,6 +1,6 @@
 # Z-Axis Assembly
 
-![exploded view of Gantry Carriage](tPictures/PS20031_2.png)
+[![exploded view of Gantry Carriage](tPictures/PS20031_2.png)](tPictures/PS20031_16.png)
 ![](tPictures/so_gantry_carriage_2.jpg)
 ![](tPictures/so_z_axis_parts_2.jpg)
 ![](tPictures/so_assembly_gantry_carriage_2.jpg)


### PR DESCRIPTION
i was going to clone this down locally and test it, but the repo is just too big... and for some reason the speeds from github are really slow for me.  Anyhow, I used the online editor to put in the markdown syntax that I think is correct for the images, and went through each one to try and verify I was pointing to the highest resolution image that was available.
