### PR TITLE
Update shapeoko 2 url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Shapeoko 2 Documentation
 
-If you are looking for the actual instructions to assemble your Shapeoko 2, please visit: http://docs.shapeoko.com. 
+If you are looking for the actual instructions to assemble your Shapeoko 2, please visit: http://shapeoko.github.io/Docs/. 
 
 ##Overview
 This is a static-dynamic site (if that's a thing?). 


### PR DESCRIPTION
docs.shapeoko.com is a dead link, unless it's going to be brought back might as well link to the github hosted page.
